### PR TITLE
add check for setAboutPanelOptions is defined

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -36,10 +36,12 @@ function createWindow() {
     mainWindow.show();
   });
 
-  app.setAboutPanelOptions({
-    applicationName: "Reacto",
-    applicationVersion: "0.0.1",
-  });
+  if (app.setAboutPanelOptions) {
+    app.setAboutPanelOptions({
+      applicationName: "Reacto",
+      applicationVersion: "0.0.1",
+    });
+  }
 }
 
 app.on('ready', () => {


### PR DESCRIPTION
without check exception[ is thrown ](https://github.com/electron/electron/issues/10451)(checked on windows 10)
