### PR TITLE
Now using cross-env module for setting env variables in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "homepage": "./",
   "main": "public/main.js",
   "scripts": {
-    "start": "BROWSER=none yarn start:all",
+    "start": "cross-env BROWSER=none yarn start:all",
     "start:js": "node scripts/start.js",
     "start:all": "npm-run-all -p watch:css start:js",
     "build": "npm-run-all build:css build:js",
@@ -58,6 +58,7 @@
     "chokidar": "^2.0.2",
     "classnames": "^2.2.5",
     "codemirror": "^5.35.0",
+    "cross-env": "^5.1.4",
     "cross-spawn": "^6.0.5",
     "css-loader": "^0.28.10",
     "dotenv": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2307,6 +2307,13 @@ create-react-class@15.x, create-react-class@^15.5.2, create-react-class@^15.5.3,
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+cross-env@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.4.tgz#f61c14291f7cc653bb86457002ea80a04699d022"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
 cross-spawn-async@^2.1.1:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
@@ -4990,13 +4997,13 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-windows@^1.0.0, is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
 is-windows@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
-
-is-windows@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 is-wsl@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Allow environment variables to be set inside npm scripts, using [cross-env](https://www.npmjs.com/package/cross-env).
Referring to this issue https://github.com/eveningkid/reacto/issues/9