### PR TITLE
Remember each open file state (cursor, scrolling, ...)

### DIFF
--- a/src/components/Editor/Editor.jsx
+++ b/src/components/Editor/Editor.jsx
@@ -46,6 +46,7 @@ class Editor extends React.Component {
     currentFile: PropTypes.instanceOf(FileType),
     currentFileHasUnsavedChanges: PropTypes.func,
     currentFileHasNoUnsavedChanges: PropTypes.func,
+    doc: PropTypes.object,
     editor: PropTypes.object,
     generatedCode: PropTypes.string,
     hasUnsavedChanges: PropTypes.bool,
@@ -158,7 +159,12 @@ class Editor extends React.Component {
           this.state.code
         );
 
-        this.props.editor.operation(() => this.props.editor.setValue(code));
+        if (nextProps.doc) {
+          this.props.editor.swapDoc(nextProps.doc);
+        } else {
+          this.props.editor.operation(() => this.props.editor.setValue(code));
+        }
+
         this.props.editor.focus();
       });
     }
@@ -305,6 +311,7 @@ const mapStateToProps = state => ({
   editor: state.session.editor,
   linter: state.project.linter,
   code: state.session.currentSession.code,
+  doc: state.session.currentSession.doc,
   originalCode: state.session.currentSession.originalCode,
   generatedCode: state.session.currentSession.generatedCode,
   currentFile: state.session.currentFile,

--- a/src/store/models/session.js
+++ b/src/store/models/session.js
@@ -27,6 +27,7 @@ const emptySession = {
   originalCode: '',
   cursor: null,
   currentFileHasUnsavedChanges: false,
+  doc: null,
 };
 
 const initialState = {
@@ -55,6 +56,8 @@ export default {
           ...state.allSessions,
           [state.currentFile.filePath]: {
             ...state.currentSession,
+            // true will copy history too
+            doc: state.editor.getDoc().copy(true),
           },
         },
       };


### PR DESCRIPTION
Refer to #63.

Fixed saving a copy of `Codemirror.doc` when switching files using `editor.getDoc().copy(true)`.
Will get a copy of the document state at this moment, plus the document history.