### PR TITLE
Removed service worker

### DIFF
--- a/src/components/_containers/Root.js
+++ b/src/components/_containers/Root.js
@@ -4,7 +4,6 @@ import { getPersistor } from '@rematch/persist';
 import { connect, Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/es/integration/react';
 import { EditorWrapper, OpenProject } from '.';
-const log = window.require('electron-log');
 
 /**
  * Root component. Will decide whether to display the code editor or the
@@ -20,21 +19,7 @@ class Root extends React.Component {
     super(props);
     this.state = {
       blockRedirect: false,
-      workerReady: false,
     };
-
-    navigator.serviceWorker
-      .register('worker.js')
-      .then(navigator.serviceWorker.ready)
-      .then(() => {
-        if (!navigator.serviceWorker.controller) {
-          // TODO Check instead whenever the service worker is installed
-          window.location.reload();
-        } else {
-          this.setState({ workerReady: true });
-        }
-      })
-      .catch(error => log.error('Service worker registration failed:', error));
   }
 
   componentWillReceiveProps(nextProps) {
@@ -48,8 +33,6 @@ class Root extends React.Component {
   }
 
   render() {
-    if (!this.state.workerReady) return null;
-
     const persistor = getPersistor();
 
     return (


### PR DESCRIPTION
As service worker initialization seemed to be an issue for some users, I decided to get rid of it after comparing using or not using it. Turned out that not using it wouldn't slow down much the software.

Got rid of it, makes it easier to keep control over what process child instances are spawned over time.

That should also fix #69 at the same time. :)