### PR TITLE
Added settings to hide .dot documents and git ignored files

### DIFF
--- a/src/components/FileTree/FileTree.jsx
+++ b/src/components/FileTree/FileTree.jsx
@@ -68,14 +68,23 @@ class FileTree extends React.Component {
     const newPathSoFar = pathSoFar + '/' + fileName;
     let title = fileName;
     const isDirectory = subTree ? true : false;
+    const isGitIgnored = fileGitStatus && fileGitStatus === 'ignored';
     const isDotFile = fileName.startsWith('.');
+
+    if (
+      (isGitIgnored && config().fileTree.hideGitIgnoredFiles) ||
+      (isDotFile && config().fileTree.hideDotDocuments)
+    ) {
+      return null;
+    }
+
     const shortenPath = newPathSoFar.replace(this.props.cwd, '').substr(1);
     const fileGitStatus = this.props.filesStatus[shortenPath];
     const classes = classNames({
       'secondary-file': isDotFile,
       'git-status-modified': fileGitStatus && fileGitStatus === 'modified',
       'git-status-new': fileGitStatus && fileGitStatus === 'new',
-      'git-status-ignored': fileGitStatus && fileGitStatus === 'ignored',
+      'git-status-ignored': isGitIgnored,
     });
     return (
       <Tree.TreeNode

--- a/src/components/_ui/Tree/Tree.jsx
+++ b/src/components/_ui/Tree/Tree.jsx
@@ -105,6 +105,8 @@ class Tree extends React.Component {
     onSelect: PropTypes.func,
   };
   static mapPropsToChildren = (context, children, props) => {
+    if (!children) children = [];
+    children = children.filter(child => child !== null);
     return React.Children.map(
       children,
       child => {

--- a/src/config.js
+++ b/src/config.js
@@ -48,6 +48,16 @@ export const custom = {
   ],
   fileTree: [
     {
+      name: 'Hide .dot documents',
+      path: 'fileTree.hideDotDocuments',
+      default: false,
+    },
+    {
+      name: 'Hide git ignored files',
+      path: 'fileTree.hideGitIgnoredFiles',
+      default: false,
+    },
+    {
       name: 'Hide node modules',
       path: 'fileTree.hideNodeModules',
       default: true,


### PR DESCRIPTION
Based on #40.

<img width="332" alt="screenshot at apr 20 17-02-09" src="https://user-images.githubusercontent.com/7188494/39042078-94e126aa-44bc-11e8-8113-a29b9699ad1b.png">

Shows a much more clearer project structure now when activated. :)