### PR TITLE
Implement handleCommandLine on appReady

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -6,6 +6,7 @@ require('fix-path')();
 
 const windowConfiguration = require('./window/configuration');
 const menu = require('./window/menu');
+const ready = require('./window/ready');
 const shortcuts = require('./window/shortcuts');
 const events = require('./window/events');
 
@@ -16,6 +17,7 @@ sweet()
   )
   .window(windowConfiguration)
   .menu(menu)
+  .ready(ready)
   .rendererEvents(events)
   .shortcuts(shortcuts)
   .run();

--- a/public/window/menu.js
+++ b/public/window/menu.js
@@ -1,5 +1,6 @@
 const { app, dialog } = require('electron');
 const checkForUpdates = require('./updater');
+const symlink = require('./symlink');
 
 const fullAppName = `${app.getName()} ${app.getVersion()}`;
 
@@ -16,6 +17,14 @@ module.exports = (is, mainWindow, app) => {
           label: 'Preferences...',
           accelerator: 'CmdOrCtrl+,',
           click: () => mainWindow.webContents.send('toggle-settings'),
+        },
+        {
+          label: 'Install Shell Command',
+          click: symlink.create,
+        },
+        {
+          label: 'Uninstall Shell Command',
+          click: symlink.remove,
         },
         { type: 'separator' },
         { role: 'hide' },

--- a/public/window/ready.js
+++ b/public/window/ready.js
@@ -1,0 +1,25 @@
+const path = require('path');
+const fs = require('fs');
+
+function handleCommandLine(mainWindow) {
+  let directory;
+  if (path.isAbsolute(process.argv[1])) {
+    directory = process.argv[1];
+  } else {
+    directory = path.join(process.cwd(), process.argv[1]);
+  }
+  if (fs.lstatSync(directory).isDirectory()) {
+    if (mainWindow) {
+      mainWindow.webContents.on('did-finish-load', () => {
+        mainWindow.webContents.send('switch-project', directory);
+      });
+    }
+  }
+  process.exit(0);
+}
+
+module.exports = (is, mainWindow) => {
+  if (!is.dev() && process.argv[1]) {
+    handleCommandLine(mainWindow);
+  }
+};

--- a/public/window/symlink.js
+++ b/public/window/symlink.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+const { app } = require('electron');
+
+module.exports = {
+  create: () => {
+    if (process.platform === 'darwin') {
+      const binaryPath = path.join(
+        app.getAppPath(),
+        '../../MacOS',
+        app.getName()
+      );
+      const link = path.join('/usr/local/bin', app.getName().toLowerCase());
+      fs.symlink(binaryPath, link, err => {
+        if (err) {
+          if (err.code === 'EEXIST') {
+            console.log('Link already exists!');
+          } else {
+            console.log(
+              'Error when trying to create symlink.',
+              binaryPath,
+              link,
+              err
+            );
+          }
+        } else {
+          console.log('Symlink succesfully created.');
+        }
+      });
+    } else {
+      console.log('Only darwin platform symlink creation implemented.');
+    }
+  },
+  remove: () => {
+    if (process.platform === 'darwin') {
+      const link = path.join('/usr/local/bin', app.getName().toLowerCase());
+      fs.unlink(link, err => {
+        if (err) {
+          console.log('Error trying to delete symlink.', err);
+        } else {
+          console.log('Symlink successfuly deleted.');
+        }
+      });
+    } else {
+      console.log('Only darwin platform symlink creation implemented.');
+    }
+  },
+};

--- a/src/editor/events/index.js
+++ b/src/editor/events/index.js
@@ -4,6 +4,7 @@ import { default as quickTabSwitch } from './quick-tab-switch';
 import { default as saveFile } from './save-file';
 import { default as search } from './search';
 import { default as switchPackageManager } from './switch-package-manager';
+import { default as switchProject } from './switch-project';
 import { default as componentPreview } from './component-preview';
 import { default as formatCurrentFile } from './format-current-file';
 import { default as toggleUIElements } from './toggle-ui-elements';
@@ -22,6 +23,7 @@ const events = {
   search,
   switchPackageManagerToNpm: switchPackageManager.switchPackageManagerToNpm,
   switchPackageManagerToYarn: switchPackageManager.switchPackageManagerToYarn,
+  switchProject,
   toggleUIBrickSelector: toggleUIElements.toggleUIBrickSelector,
   toggleUIFileTree: toggleUIElements.toggleUIFileTree,
 };
@@ -34,6 +36,7 @@ EventsManager.on('new-file', events.newFile)
   .on('quick-switch-tab-forward', events.quickTabSwitchForward)
   .on('switch-package-manager-to-npm', events.switchPackageManagerToNpm)
   .on('switch-package-manager-to-yarn', events.switchPackageManagerToYarn)
+  .on('switch-project', events.switchProject)
   .on('component-preview', events.componentPreview)
   .on('format-current-file', events.formatCurrentFile)
   .on('toggle-ui-file-tree', events.toggleUIFileTree)

--- a/src/editor/events/switch-project.js
+++ b/src/editor/events/switch-project.js
@@ -1,0 +1,5 @@
+import { dispatch } from '@rematch/core';
+
+export default function switchProject(_, path) {
+  dispatch.project.switchProject(path);
+}


### PR DESCRIPTION
Ok. I've implemented the handleCommandLine function on app.ready and the create and remove symlink for the darwin platform in order to be able to open reacto from cli. There's one problem though. The app does not detach from cli. To be able to do that I'd have to actually build a command line application that can spawn a child process on the background and exit. From what I know, it is not possible to do that from inside the electron binary.